### PR TITLE
Add an icon if a job is behind schedule

### DIFF
--- a/src/CronJobListBuilder.php
+++ b/src/CronJobListBuilder.php
@@ -8,7 +8,6 @@
 namespace Drupal\ultimate_cron;
 
 use Drupal\Component\Utility\SafeMarkup;
-use Drupal\Core\Url;
 use Drupal\Core\Config\Entity\ConfigEntityListBuilder;
 use Drupal\Core\Entity\EntityInterface;
 

--- a/src/CronJobListBuilder.php
+++ b/src/CronJobListBuilder.php
@@ -40,8 +40,6 @@ class CronJobListBuilder extends ConfigEntityListBuilder {
     $job_status = SafeMarkup::format('<img src="@s" title="@l"><span></span></img>', array("@s" => file_create_url($icon), "@l" => "Job is behind schedule!"));
 
     $entry = $entity->loadLatestLogEntry();
-    // Start and end as UNIX timestamps.
-    // Duration in milliseconds.
     $row['module'] = array(
       'data' => SafeMarkup::checkPlain($entity->getModuleName()),
       'class' => array('ctools-export-ui-module'),
@@ -54,7 +52,9 @@ class CronJobListBuilder extends ConfigEntityListBuilder {
     else {
       $row['scheduled'] = $entity->getPlugin('scheduler')->formatLabel($entity);
     }
+    // If the start time is 0, the jobs have never been run.
     $row['started'] = $entry->start_time ? \Drupal::service('date.formatter')->format($entry->start_time, "short") : $this->t('Never');
+    // In milliseconds.
     $row['duration'] = round(($entry->end_time - $entry->start_time) * 1000, 0);
     $row['status'] = $entity->status() ? $this->t('Yes') : $this->t('No');
     return $row + parent::buildRow($entity);

--- a/src/CronJobListBuilder.php
+++ b/src/CronJobListBuilder.php
@@ -8,7 +8,7 @@
 namespace Drupal\ultimate_cron;
 
 use Drupal\Component\Utility\SafeMarkup;
-use Drupal\Component\Utility\String;
+use Drupal\Core\Url;
 use Drupal\Core\Config\Entity\ConfigEntityListBuilder;
 use Drupal\Core\Entity\EntityInterface;
 
@@ -27,17 +27,19 @@ class CronJobListBuilder extends ConfigEntityListBuilder {
     $header['module'] = array('data' => t('Module'));
     $header['title'] = array('data' => t('Title'));
     $header['scheduled'] = array('data' => t('Scheduled'));
-    $header['started'] = array('data' => t('Started'));
-    $header['duration'] = array('data' => t('Duration'));
+    $header['started'] = array('data' => t('Last Run'));
+    $header['duration'] = array('data' => t('Duration in ms'));
     $header['status'] = array('data' => t('Status'));
     return $header + parent::buildHeader();
   }
-
   /**
    * {@inheritdoc}
    */
   public function buildRow(EntityInterface $entity) {
     /* @var \Drupal\ultimate_cron\Entity\CronJob $entity */
+    $icon = drupal_get_path('module', 'ultimate_cron') . '/icons/hourglass.png';
+    $job_status = SafeMarkup::format('<img src="@s" title="@l"><span></span></img>', array("@s" => file_create_url($icon), "@l" => "Job is behind schedule!"));
+
     $entry = $entity->loadLatestLogEntry();
     // Start and end as UNIX timestamps.
     // Duration in milliseconds.
@@ -47,9 +49,14 @@ class CronJobListBuilder extends ConfigEntityListBuilder {
       'title' => strip_tags($entity->getModuleDescription()),
     );
     $row['title'] = $this->getLabel($entity);
-    $row['scheduled'] = $entity->getPlugin('scheduler')->formatLabel($entity);
-    $row['started'] = \Drupal::service('date.formatter')->format($entry->start_time, "short");
-    $row['duration'] = $this->t('(%durations)', array('%duration' => round($entry->end_time - $entry->start_time, 3)));
+    if ($entity->isScheduled()) {
+      $row['scheduled'] = SafeMarkup::format('@label !icon', array('@label' => $entity->getPlugin('scheduler')->formatLabel($entity), '!icon' => $job_status));
+    }
+    else {
+      $row['scheduled'] = $entity->getPlugin('scheduler')->formatLabel($entity);
+    }
+    $row['started'] = $entry->start_time ? \Drupal::service('date.formatter')->format($entry->start_time, "short") : $this->t('Never');
+    $row['duration'] = round(($entry->end_time - $entry->start_time) * 1000, 0);
     $row['status'] = $entity->status() ? $this->t('Yes') : $this->t('No');
     return $row + parent::buildRow($entity);
   }

--- a/src/Entity/CronJob.php
+++ b/src/Entity/CronJob.php
@@ -97,7 +97,7 @@ class CronJob extends ConfigEntityBase implements CronJobInterface {
   public function postSave(EntityStorageInterface $storage, $update = TRUE) {
     parent::postSave($storage, $update);
     if ($update && empty($this->dont_log)) {
-      $log = $this->startLog(uniqid($this->id(), TRUE));
+      $log = $this->startLog(uniqid($this->id(), TRUE), '', ULTIMATE_CRON_LOG_TYPE_ADMIN);
       $log->log($this->id(), 'Job modified by ' . $log->formatUser(), array(), RfcLogLevel::INFO);
       $log->finish();
     }

--- a/src/Plugin/ultimate_cron/Scheduler/Crontab.php
+++ b/src/Plugin/ultimate_cron/Scheduler/Crontab.php
@@ -165,7 +165,7 @@ class Crontab extends SchedulerBase {
       }
       $job_last_ran = $registered[$job->id()];
     }
-    
+
     $settings = $job->getSettings($this->type);
 
     $skew = $this->getSkew($job);

--- a/src/Plugin/ultimate_cron/Scheduler/Crontab.php
+++ b/src/Plugin/ultimate_cron/Scheduler/Crontab.php
@@ -165,7 +165,6 @@ class Crontab extends SchedulerBase {
       }
       $job_last_ran = $registered[$job->id()];
     }
-
     $settings = $job->getSettings($this->type);
 
     $skew = $this->getSkew($job);

--- a/src/Plugin/ultimate_cron/Scheduler/Crontab.php
+++ b/src/Plugin/ultimate_cron/Scheduler/Crontab.php
@@ -165,6 +165,7 @@ class Crontab extends SchedulerBase {
       }
       $job_last_ran = $registered[$job->id()];
     }
+    
     $settings = $job->getSettings($this->type);
 
     $skew = $this->getSkew($job);

--- a/src/Tests/CronJobFormTest.php
+++ b/src/Tests/CronJobFormTest.php
@@ -50,10 +50,10 @@ class CronJobFormTest extends WebTestBase {
     $this->drupalGet('admin/config/system/cron/jobs');
     $this->assertResponse('200');
 
-    // Check for the default schedule.
-    $this->assertText('Every 15 min', "Job has correct schedule.");
-    // Check that the Cron job has never run.
-    $this->assertText('Never', "Job has not run yet.");
+    // Check for the default schedule message in Job list.
+    $this->assertText('Every 15 min');
+    // Check for the Last Run default value.
+    $this->assertText('Never');
 
     // Start adding a new job.
     $this->clickLink(t('Add job'));

--- a/src/Tests/CronJobFormTest.php
+++ b/src/Tests/CronJobFormTest.php
@@ -94,14 +94,16 @@ class CronJobFormTest extends WebTestBase {
     $this->assertText(t('job @name has been updated.', array('@name' => $this->job_name)));
 
     // Run the Jobs.
-    $this->drupalGet('admin/config/system/cron/');
-    $this->drupalPostForm(NULL, array(), t('Run cron'));
+    $this->cronRun();
 
-    // Assert the cron jobs hav been run.
+    // Assert the cron jobs have been run by checking the time.
     $this->drupalGet('admin/config/system/cron/jobs');
-    $this->assertNoUniqueText(SafeMarkup::format('@time', array('@time' => \Drupal::service('date.formatter')->format(time(), "short"))), "Created Cron jobs have been run.");
+    $this->assertNoUniqueText(SafeMarkup::format('@time', array('@time' => \Drupal::service('date.formatter')->format(\Drupal::state()->get('system.cron_last'), "short"))), "Created Cron jobs have been run.");
 
-    //Assert cron job overview for recently updated job.
+    // Check that all jobs have been run.
+    $this->assertNoText("Never");
+
+    // Assert cron job overview for recently updated job.
     $this->drupalGet('admin/config/system/cron/jobs');
     $this->assertNoText($old_job_name);
     $this->assertText($this->job_name);

--- a/src/Tests/CronJobFormTest.php
+++ b/src/Tests/CronJobFormTest.php
@@ -84,14 +84,22 @@ class CronJobFormTest extends WebTestBase {
     // Set new cron job configuration and save the old job name.
     $old_job_name = $this->job_name;
     $this->job_name = 'edited job name';
-    $edit = array('title' => $this->job_name,);
+    $edit = array('title' => $this->job_name);
 
     // Save the new job.
     $this->drupalPostForm(NULL, $edit, t('Save'));
-    $this->assertText(SafeMarkup::format('@time', array('@time' => \Drupal::service('date.formatter')->format(time(), "short"))), "Created Cron job has been run.");
-
-    // Assert drupal_set_message for successful updated job.
+    // Assert the edited Job hasn't run yet.
+    $this->assertNoUniqueText('Never');
     $this->assertText(t('job @name has been updated.', array('@name' => $this->job_name)));
+
+    // Run the Jobs.
+    $this->drupalGet('admin/config/system/cron/');
+    $this->drupalPostForm(NULL, array(), t('Run cron'));
+
+    // Assert the cron jobs hav been run.
+    $this->drupalGet('admin/config/system/cron/jobs');
+    $this->assertNoUniqueText(SafeMarkup::format('@time', array('@time' => \Drupal::service('date.formatter')->format(time(), "short"))), "Created Cron jobs have been run.");
+    // Assert drupal_set_message for successful updated job.
 
     //Assert cron job overview for recently updated job.
     $this->drupalGet('admin/config/system/cron/jobs');

--- a/src/Tests/CronJobFormTest.php
+++ b/src/Tests/CronJobFormTest.php
@@ -7,6 +7,7 @@
 namespace Drupal\ultimate_cron\Tests;
 
 use Drupal\simpletest\WebTestBase;
+use Drupal\Component\Utility\SafeMarkup;
 
 /**
  * Cron Job Form Testing
@@ -49,6 +50,11 @@ class CronJobFormTest extends WebTestBase {
     $this->drupalGet('admin/config/system/cron/jobs');
     $this->assertResponse('200');
 
+    // Check for the default schedule.
+    $this->assertText('Every 15 min', "Job has correct schedule.");
+    // Check that the Cron job has never run.
+    $this->assertText('Never', "Job has not run yet.");
+
     // Start adding a new job.
     $this->clickLink(t('Add job'));
     $this->assertResponse('200');
@@ -82,6 +88,7 @@ class CronJobFormTest extends WebTestBase {
 
     // Save the new job.
     $this->drupalPostForm(NULL, $edit, t('Save'));
+    $this->assertText(SafeMarkup::format('@time', array('@time' => \Drupal::service('date.formatter')->format(time(), "short"))), "Created Cron job has been run.");
 
     // Assert drupal_set_message for successful updated job.
     $this->assertText(t('job @name has been updated.', array('@name' => $this->job_name)));

--- a/src/Tests/CronJobFormTest.php
+++ b/src/Tests/CronJobFormTest.php
@@ -90,6 +90,7 @@ class CronJobFormTest extends WebTestBase {
     $this->drupalPostForm(NULL, $edit, t('Save'));
     // Assert the edited Job hasn't run yet.
     $this->assertNoUniqueText('Never');
+    // Assert drupal_set_message for successful updated job.
     $this->assertText(t('job @name has been updated.', array('@name' => $this->job_name)));
 
     // Run the Jobs.
@@ -99,7 +100,6 @@ class CronJobFormTest extends WebTestBase {
     // Assert the cron jobs hav been run.
     $this->drupalGet('admin/config/system/cron/jobs');
     $this->assertNoUniqueText(SafeMarkup::format('@time', array('@time' => \Drupal::service('date.formatter')->format(time(), "short"))), "Created Cron jobs have been run.");
-    // Assert drupal_set_message for successful updated job.
 
     //Assert cron job overview for recently updated job.
     $this->drupalGet('admin/config/system/cron/jobs');


### PR DESCRIPTION
The test looks for a known schedule, tests if the system job has never run (it never runs during the test) and tests if the created job has successfully run (using the current time as an assert, might not always be correct...)
