### PR TITLE
Added delete to job operations

### DIFF
--- a/src/Entity/CronJob.php
+++ b/src/Entity/CronJob.php
@@ -28,6 +28,7 @@ use Exception;
  *     "list_builder" = "Drupal\ultimate_cron\CronJobListBuilder",
  *     "form" = {
  *       "default" = "Drupal\ultimate_cron\Form\CronJobForm",
+ *       "delete" = "\Drupal\Core\Entity\EntityDeleteForm",
  *     }
  *   },
  *   config_prefix = "job",
@@ -39,6 +40,8 @@ use Exception;
  *   },
  *   links = {
  *     "edit-form" = "/admin/config/system/cron/jobs/manage/{ultimate_cron_job}",
+ *     "delete-form" = "/adming/config/system/cron/jobs/manage/{ultimate_cron_job}/delete",
+ *     "collection" = "/admin/config/system/cron/jobs",
  *   }
  * )
  *
@@ -105,6 +108,19 @@ class CronJob extends ConfigEntityBase implements CronJobInterface {
 
   public function setConfiguration($plugin_type, $configuration) {
     $this->{$plugin_type}['configuration'] = $configuration;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function postDelete(EntityStorageInterface $storage, array $entities) {
+    foreach ($entities as $entity) {
+      if (empty($entity->dont_log)) {
+        $log = $entity->startLog(uniqid($entity->id(), TRUE), 'modification', ULTIMATE_CRON_LOG_TYPE_ADMIN);
+        $log->log($entity->id(), 'Job deleted by ' . $log->formatUser(), array(), RfcLogLevel::INFO);
+        $log->finish();
+      }
+    }
   }
 
   /**

--- a/src/Form/CronJobForm.php
+++ b/src/Form/CronJobForm.php
@@ -165,7 +165,7 @@ class CronJobForm extends EntityForm {
     else {
       drupal_set_message(t('job %label has been added.', array('%label' => $job->label())));
     }
-    $form_state->setRedirect('ultimate_cron.job_list');
+    $form_state->setRedirect('entity.ultimate_cron_job.collection');
 
   }
 

--- a/src/Tests/CronJobFormTest.php
+++ b/src/Tests/CronJobFormTest.php
@@ -112,5 +112,12 @@ class CronJobFormTest extends WebTestBase {
     $this->clickLink(t('Edit'));
     $this->drupalPostForm(NULL, ['scheduler[configuration][rules][0]' => '0+@ */6 * * *'], t('Save'));
     $this->assertText('Every 6 hours');
+
+    // Test deleting a job.
+    $this->clickLink(t('Delete'), 1);
+    $this->drupalPostForm(NULL, NULL, t('Delete'));
+    $this->assertText('The cron job edited job name has been deleted.');
+    $this->drupalGet('admin/config/system/cron/jobs');
+    $this->assertNoText($this->job_name);
   }
 }

--- a/ultimate_cron.links.action.yml
+++ b/ultimate_cron.links.action.yml
@@ -3,4 +3,4 @@ ultimate_cron.job_add:
   title: 'Add job'
   weight: 1
   appears_on:
-    - ultimate_cron.job_list
+    - entity.ultimate_cron_job.collection

--- a/ultimate_cron.links.menu.yml
+++ b/ultimate_cron.links.menu.yml
@@ -2,5 +2,5 @@ system.ultimate_cron_settings:
   title: Cron jobs
   parent: system.admin_config_system
   description: 'Manage Ultimate Cron jobs.'
-  route_name: ultimate_cron.job_list
+  route_name: entity.ultimate_cron_job.collection
   weight: 20

--- a/ultimate_cron.routing.yml
+++ b/ultimate_cron.routing.yml
@@ -1,4 +1,4 @@
-ultimate_cron.job_list:
+entity.ultimate_cron_job.collection:
   path: '/admin/config/system/cron/jobs'
   defaults:
     _entity_list: 'ultimate_cron_job'
@@ -21,3 +21,11 @@ entity.ultimate_cron_job.edit_form:
     _title: 'Edit job'
   requirements:
     _entity_access: 'ultimate_cron_job.edit'
+
+entity.ultimate_cron_job.delete_form:
+  path: '/admin/config/system/cron/jobs/manage/{ultimate_cron_job}/delete'
+  defaults:
+    _entity_form: 'ultimate_cron_job.delete'
+    _title: 'Delete job'
+  requirements:
+    _entity_access: 'ultimate_cron_job.delete'


### PR DESCRIPTION
When deleting a job, I get redirected to a not existing page (the manage page for the deleted job), where can I set the redirect after deletion?
